### PR TITLE
Added support for XDG Base Directory standard

### DIFF
--- a/src/RASW/__init__.py
+++ b/src/RASW/__init__.py
@@ -16,7 +16,7 @@ from pathlib import Path
 
 def _open_docs_on_first_run():
     """Open documentation website on first run after installation."""
-    first_run_marker = Path.home() / ".rasw_first_run"
+    first_run_marker = Path(os.environ.get('XDG_DATA_HOME', Path.home())) / ".rasw_first_run"
     if not first_run_marker.exists():
         try:
             # Create the marker file to prevent opening on subsequent imports

--- a/src/RASW/__init__.py
+++ b/src/RASW/__init__.py
@@ -16,7 +16,7 @@ from pathlib import Path
 
 def _open_docs_on_first_run():
     """Open documentation website on first run after installation."""
-    first_run_marker = Path(os.environ.get('XDG_DATA_HOME', Path.home())) / ".rasw_first_run"
+    first_run_marker = Path(os.environ.get('XDG_STATE_HOME', Path.home())) / ".rasw_first_run"
     if not first_run_marker.exists():
         try:
             # Create the marker file to prevent opening on subsequent imports


### PR DESCRIPTION
I added support for the XDG Base Directory standard. I made this change to avoid adding more files to home directories, for those with it set up. It now defaults to $XDG_STATE_HOME and uses $HOME if that variable is unset. 
I've tested this change on Linux (NixOS unstable using Pipx) and Windows 10.
XDG Base Directory Specification: https://specifications.freedesktop.org/basedir-spec/latest/